### PR TITLE
Changed HTML parsing method. (as of 2023)

### DIFF
--- a/NYTimes/Utilities/HTMLScarperUtility.swift
+++ b/NYTimes/Utilities/HTMLScarperUtility.swift
@@ -18,13 +18,14 @@ class HTMLScraperUtility {
             var articles = [Article]()
             do {
                 let elements = try SwiftSoup.parse(html, Constants.Endpoints.BASEURL)
-                let documents = try elements.getElementById("stream-panel")?.select("div").select("ol").select("div").select("div").select("a")
+                // last updated: 08-20-2023
+                let documents = try elements.getElementById("stream-panel")?.select("div").select("ol").select("article")
                 documents?.forEach({ (document) in
-                    let imageUrl = try? document.select("div").select("figure").select("div").select("img").attr("src")
-                    let title = try? document.select("h2").text()
+                    let imageUrl = try? document.select("img").attr("src")
+                    let title = try? document.select("h3").text()
                     let subtitle = try? document.select("p").text()
                     let author = try? document.select("div").select("p").select("span").text()
-                    let url = try? document.attr("href")
+                    let url = try? document.select("a").attr("href")
                     
                     if let title = title,
                        let subtitle = subtitle,
@@ -39,6 +40,8 @@ class HTMLScraperUtility {
                         
                         let article = Article(url: "https://www.nytimes.com\(url)", imageUrl: imageUrl, title: title, subtitle: subtitle, author: author)
                         articles.append(article)
+                    } else {
+                        print("parsing error")
                     }
                 })
                 promise(.success(articles))
@@ -49,5 +52,5 @@ class HTMLScraperUtility {
             }
         }
     }
-    
 }
+

--- a/NYTimes/Views/RootView.swift
+++ b/NYTimes/Views/RootView.swift
@@ -30,7 +30,7 @@ struct RootView: View {
         NavigationView {
             if networkReachability.isNetworkConnected {
                 ArticleView()
-                    .edgesIgnoringSafeArea(.all)
+                    .edgesIgnoringSafeArea(.bottom)
                     .navigationViewStyle(StackNavigationViewStyle())
                     .navigationBarTitle(Text("NYTimes"))
                     .navigationBarItems(


### PR DESCRIPTION
# Changed HTML parsing method. (as of 2023)
Dear TheCodeMonks.
As a result of running on August 20, 2023, the HTML code of the NYTimes website was changed, so there was an issue with the article list not appearing.
Accordingly, the parsing class (`HTMLScarperUtility`) has also been partially changed to match the new HTML.
I would appreciate it if you could check it out and merge the pull request.
Thank you.

## Screenshots
<img src="https://github.com/TheCodeMonks/NYTimes-iOS/assets/40187546/0afbb758-f6aa-4656-b62a-20b3797a6a46" width=30%>
<img src="https://github.com/TheCodeMonks/NYTimes-iOS/assets/40187546/17ec2aac-43de-4ff6-8453-dfe1095a9241" width=30%>
